### PR TITLE
chore(ci): remove python support from codeql workfllow as it not needed

### DIFF
--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -26,8 +26,6 @@ jobs:
             build-mode: 'none'
           - language: 'java-kotlin'
             build-mode: 'manual'
-          - language: 'python'
-            build-mode: 'none'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
We don't have python in this repository hence we don't need the scan.
