### PR TITLE
chore(build): add WebAssembly (wasmJs) support for KMP libraries

### DIFF
--- a/build-plugin/README.md
+++ b/build-plugin/README.md
@@ -109,6 +109,29 @@ plugins {
 }
 ```
 
+### Gradle project isolation and Wasm
+
+Gradle isolated projects are enabled, but configuration cache problems are currently reported as warnings:
+
+```properties
+org.gradle.unsafe.isolated-projects=true
+org.gradle.configuration-cache.problems=warn
+```
+
+This is intentional while the Kotlin Wasm `nodejs()` target is experimental. Enabling the Wasm Node/NPM tooling makes
+`wasmJsNodeTest` execute real tests, but the Kotlin Gradle plugin currently configures Wasm Node, NPM, and Binaryen
+through cross-project access patterns that are not compatible with isolated-project enforcement.
+
+Do not change `org.gradle.configuration-cache.problems` from `warn` to `fail` while the Wasm target is enabled. The
+expected migration path is to keep the warnings visible, track the Kotlin Gradle plugin fixes, and only enforce `fail`
+once the upstream Wasm tooling is isolated-project compatible.
+
+Wasm Node tooling also needs centralized repository handling because this build uses
+`RepositoriesMode.FAIL_ON_PROJECT_REPOS`. The Node distribution repository is declared in `settings.gradle.kts`, and
+the Wasm convention plugins unset Kotlin's default Node download base URL so Kotlin resolves Node through the settings
+repository instead of adding a project repository. `kotlin.js.yarn=false` is intentional because Kotlin's Yarn setup
+adds a project repository for the Yarn distribution.
+
 ### Code coverage configuration
 
 When using `net.thunderbird.gradle.plugin.quality.coverage` you can tune or disable coverage checks:

--- a/build-plugin/plugin/build.gradle.kts
+++ b/build-plugin/plugin/build.gradle.kts
@@ -48,6 +48,10 @@ gradlePlugin {
             id = "net.thunderbird.gradle.plugin.bom"
             implementationClass = "net.thunderbird.gradle.plugin.bom.BomPlugin"
         }
+        register("WasmRepositories") {
+            id = "net.thunderbird.gradle.plugin.wasm.repositories"
+            implementationClass = "net.thunderbird.gradle.plugin.wasm.WasmRepositoriesPlugin"
+        }
 
         register("DependencyCheck") {
             id = "net.thunderbird.gradle.plugin.dependency.check"

--- a/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/library/kmp/LibraryKmpPlugin.kt
+++ b/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/library/kmp/LibraryKmpPlugin.kt
@@ -2,17 +2,19 @@ package net.thunderbird.gradle.plugin.library.kmp
 
 import net.thunderbird.gradle.plugin.ProjectConfig
 import net.thunderbird.gradle.plugin.libs
+import net.thunderbird.gradle.plugin.wasm.useSettingsRepositoryForWasmNodeJsDistribution
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.invoke
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 /**
  * A Gradle plugin to configure a Kotlin Multiplatform Library project.
  *
- * Supported platforms include Android, iOS (x64, Arm64, Simulator Arm64), and JVM.
+ * Supported platforms include Android, iOS (Arm64, Simulator Arm64), JVM, and WebAssembly.
  *
  * It sets up the necessary plugins, targets, source sets, and dependencies.
  */
@@ -34,7 +36,7 @@ class LibraryKmpPlugin : Plugin<Project> {
                 apply("net.thunderbird.gradle.plugin.quality.spotless")
             }
 
-            @OptIn(ExperimentalAbiValidation::class)
+            @OptIn(ExperimentalAbiValidation::class, ExperimentalWasmDsl::class)
             extensions.configure<KotlinMultiplatformExtension> {
                 explicitApi()
                 abiValidation()
@@ -64,6 +66,11 @@ class LibraryKmpPlugin : Plugin<Project> {
                     }
                 }
 
+                wasmJs {
+                    nodejs()
+                }
+                useSettingsRepositoryForWasmNodeJsDistribution()
+
                 sourceSets {
                     commonMain.dependencies {
                         implementation(project.dependencies.platform(libs.kotlin.bom))
@@ -92,6 +99,13 @@ class LibraryKmpPlugin : Plugin<Project> {
                     }
                     nativeTest.dependencies {
                         implementation(libs.bundles.shared.kmp.native.test)
+                    }
+
+                    wasmJsMain.dependencies {
+                        implementation(libs.bundles.shared.kmp.wasm)
+                    }
+                    wasmJsTest.dependencies {
+                        implementation(libs.bundles.shared.kmp.wasm.test)
                     }
                 }
             }

--- a/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/library/kmp/compose/LibraryKmpComposePlugin.kt
+++ b/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/library/kmp/compose/LibraryKmpComposePlugin.kt
@@ -5,17 +5,19 @@ import net.thunderbird.gradle.plugin.library.kmp.android
 import net.thunderbird.gradle.plugin.library.kmp.androidHostTest
 import net.thunderbird.gradle.plugin.library.kmp.namespaceByPath
 import net.thunderbird.gradle.plugin.libs
+import net.thunderbird.gradle.plugin.wasm.useSettingsRepositoryForWasmNodeJsDistribution
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.invoke
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 /**
  * A Gradle plugin to configure a Kotlin Multiplatform Compose Library project.
  *
- * Supported platforms include Android, iOS (x64, Arm64, Simulator Arm64), and JVM.
+ * Supported platforms include Android, iOS (Arm64, Simulator Arm64), JVM, and WebAssembly.
  *
  * It sets up the necessary plugins, targets, source sets, dependencies, and Compose settings.
  */
@@ -39,7 +41,7 @@ class LibraryKmpComposePlugin : Plugin<Project> {
                 apply("net.thunderbird.gradle.plugin.quality.spotless")
             }
 
-            @OptIn(ExperimentalAbiValidation::class)
+            @OptIn(ExperimentalAbiValidation::class, ExperimentalWasmDsl::class)
             extensions.configure<KotlinMultiplatformExtension> {
                 explicitApi()
                 abiValidation()
@@ -72,6 +74,11 @@ class LibraryKmpComposePlugin : Plugin<Project> {
                         jvmTarget.set(ProjectConfig.Compiler.jvmTarget)
                     }
                 }
+
+                wasmJs {
+                    nodejs()
+                }
+                useSettingsRepositoryForWasmNodeJsDistribution()
 
                 sourceSets {
                     commonMain.dependencies {
@@ -109,6 +116,15 @@ class LibraryKmpComposePlugin : Plugin<Project> {
                     nativeTest.dependencies {
                         implementation(libs.bundles.shared.kmp.native.test)
                         implementation(libs.bundles.shared.kmp.compose.native.test)
+                    }
+
+                    wasmJsMain.dependencies {
+                        implementation(libs.bundles.shared.kmp.wasm)
+                        implementation(libs.bundles.shared.kmp.compose.wasm)
+                    }
+                    wasmJsTest.dependencies {
+                        implementation(libs.bundles.shared.kmp.wasm.test)
+                        implementation(libs.bundles.shared.kmp.compose.wasm.test)
                     }
                 }
             }

--- a/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/wasm/WasmRepositoriesPlugin.kt
+++ b/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/wasm/WasmRepositoriesPlugin.kt
@@ -1,0 +1,52 @@
+package net.thunderbird.gradle.plugin.wasm
+
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsEnvSpec
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin
+
+/**
+ * Routes the Wasm Node.js distribution download through the repository declared in `settings.gradle.kts`.
+ *
+ * This build uses [org.gradle.api.initialization.resolve.RepositoriesMode.FAIL_ON_PROJECT_REPOS], but Kotlin's Wasm
+ * Node tooling would otherwise add a project-level repository for the Node distribution. Unsetting the default
+ * download base URL makes Kotlin resolve Node through the settings repository instead.
+ *
+ * Applied to the root project, this configures the root Node.js spec that drives the shared Node download. The
+ * per-project Node setup tasks need the same treatment, applied via
+ * [useSettingsRepositoryForWasmNodeJsDistribution].
+ */
+class WasmRepositoriesPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        require(target == target.rootProject) {
+            "The Wasm repositories plugin must be applied to the root project."
+        }
+
+        target.plugins.apply(WasmNodeJsRootPlugin::class.java)
+        target.plugins.withType(WasmNodeJsRootPlugin::class.java).configureEach {
+            target.configureWasmNodeJsSpec()
+        }
+    }
+}
+
+/**
+ * Configures this project's Wasm Node.js spec to resolve the Node distribution through the settings repository.
+ *
+ * See [WasmRepositoriesPlugin] for the rationale. Call this from a Kotlin Multiplatform module that enables the
+ * `wasmJs` target so its per-project `kotlinWasmNodeJsSetup` task does not add a project-level repository.
+ */
+fun Project.useSettingsRepositoryForWasmNodeJsDistribution() {
+    plugins.withType(WasmNodeJsPlugin::class.java).configureEach {
+        configureWasmNodeJsSpec()
+    }
+}
+
+private fun Project.configureWasmNodeJsSpec() {
+    extensions.configure("kotlinWasmNodeJsSpec", useSettingsRepositoryForWasmNodeJsDistribution)
+}
+
+private val useSettingsRepositoryForWasmNodeJsDistribution = Action<WasmNodeJsEnvSpec> {
+    downloadBaseUrl.unset()
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     alias(libs.plugins.tb.quality.code.coverage)
     alias(libs.plugins.tb.quality.detekt)
     alias(libs.plugins.tb.quality.spotless)
+    alias(libs.plugins.tb.wasm.repositories)
 }
 
 tasks.named<Wrapper>("wrapper") {

--- a/components/core/outcome/api/outcome.klib.api
+++ b/components/core/outcome/api/outcome.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,10 +16,13 @@ org.gradle.configuration-cache.parallel=true
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.tooling.parallel=true
 org.gradle.unsafe.isolated-projects=true
+org.gradle.configuration-cache.problems=warn
 # Kotlin
 kotlin.code.style=official
 kotlin.incremental=true
 kotlin.compiler.execution.strategy=in-process
+## Use npm for Kotlin Wasm/JS tooling to avoid Yarn's project-level distribution repository.
+kotlin.js.yarn=false
 ## Dokka workaround for Gradle project isolation violations
 ## See https://github.com/Kotlin/dokka/issues/4488
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ tb-quality-code-coverage = { id = "net.thunderbird.gradle.plugin.quality.coverag
 tb-quality-detekt = { id = "net.thunderbird.gradle.plugin.quality.detekt" }
 tb-quality-spotless = { id = "net.thunderbird.gradle.plugin.quality.spotless" }
 tb-versioning = { id = "net.thunderbird.gradle.plugin.versioning" }
+tb-wasm-repositories = { id = "net.thunderbird.gradle.plugin.wasm.repositories" }
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidXActivity" }
@@ -110,6 +111,8 @@ shared-kmp-jvm = [
 ]
 shared-kmp-native = [
 ]
+shared-kmp-wasm = [
+]
 
 shared-kmp-common-test = [
   "assertk",
@@ -123,6 +126,8 @@ shared-kmp-android-test = [
 shared-kmp-jvm-test = [
 ]
 shared-kmp-native-test = [
+]
+shared-kmp-wasm-test = [
 ]
 
 shared-kmp-compose-commmon = [
@@ -145,6 +150,8 @@ shared-kmp-compose-jvm = [
 ]
 shared-kmp-compose-native = [
 ]
+shared-kmp-compose-wasm = [
+]
 
 shared-kmp-compose-common-test = [
   "jetbrains-compose-ui-test"
@@ -152,6 +159,8 @@ shared-kmp-compose-common-test = [
 shared-kmp-compose-android-test = [
   "androidx-compose-ui-test-manifest",
   "robolectric",
+]
+shared-kmp-compose-wasm-test = [
 ]
 shared-kmp-compose-jvm-test = [
 ]

--- a/kotlin-js-store/wasm/package-lock.json
+++ b/kotlin-js-store/wasm/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "tmc",
+  "version": "unspecified",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tmc",
+      "version": "unspecified",
+      "workspaces": [
+        "packages/tmc-components-core-outcome",
+        "packages/tmc-components-core-outcome-test",
+        "packages_imported/Kotlin-DateTime-library-kotlinx-datetime-wasm-js/0.8.0"
+      ],
+      "devDependencies": {}
+    },
+    "node_modules/@js-joda/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/Kotlin-DateTime-library-kotlinx-datetime-wasm-js": {
+      "resolved": "packages_imported/Kotlin-DateTime-library-kotlinx-datetime-wasm-js/0.8.0",
+      "link": true
+    },
+    "node_modules/tmc-components-core-outcome": {
+      "resolved": "packages/tmc-components-core-outcome",
+      "link": true
+    },
+    "node_modules/tmc-components-core-outcome-test": {
+      "resolved": "packages/tmc-components-core-outcome-test",
+      "link": true
+    },
+    "packages_imported/Kotlin-DateTime-library-kotlinx-datetime-wasm-js/0.8.0": {
+      "name": "Kotlin-DateTime-library-kotlinx-datetime-wasm-js",
+      "version": "0.8.0",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    },
+    "packages/tmc-components-core-outcome": {
+      "version": "0.1.0-SNAPSHOT",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    },
+    "packages/tmc-components-core-outcome-test": {
+      "version": "0.1.0-SNAPSHOT",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,18 @@ dependencyResolutionManagement {
             }
         }
         mavenCentral()
+        ivy("https://nodejs.org/dist") {
+            name = "Node.js distributions"
+            patternLayout {
+                artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]")
+            }
+            metadataSources {
+                artifact()
+            }
+            content {
+                includeModule("org.nodejs", "node")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This change adds Wasm support for KMP libraries, enabling us to deploy the Bolt catalog as a web app for easier access for designers. Because the Wasm plugin is not yet fully compatible with Gradle project isolation (support is expected in Kotlin 2.5), this introduces some isolation violations. To prevent these from failing the build, project isolation mode has been set to `warn`. This is an acceptable temporary compromise, as it does not affect CI and only slightly reduces the effectiveness of the Gradle configuration cache for local builds.