### PR TITLE
chore(ci): add snapshot manifest

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -63,11 +63,22 @@ jobs:
           ./gradlew validateSnapshotVersionForPublishing
           ./gradlew publishToMavenCentral
 
+      - name: Write snapshot manifest
+        if: steps.snapshot-marker.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+
+          manifest="${RUNNER_TEMP}/snapshot-manifest.md"
+          scripts/ci/write-snapshot-manifest.sh "${manifest}"
+          cat "${manifest}" >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Update snapshot marker
         if: steps.snapshot-marker.outputs.publish == 'true'
         run: |
           set -euo pipefail
 
           marker="snapshot/latest"
-          git tag --force "${marker}" HEAD
+          git config user.name "TMC Snapshot Bot"
+          git config user.email "tmc-snapshot-bot@thunderbird.net"
+          git tag --annotate --force "${marker}" --file "${RUNNER_TEMP}/snapshot-manifest.md" HEAD
           git push --force origin "refs/tags/${marker}"

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -353,6 +353,7 @@ naming:
       - 'ios'
       - 'android'
       - 'js'
+      - 'wasmJs'
       - 'jvm'
       - 'native'
       - 'iosArm64'

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -197,6 +197,16 @@ The `Publish Snapshot` workflow is triggered manually from `main` and publishes 
 The workflow skips publishing when the mutable `snapshot/latest` marker tag already points at the current `main`
 commit. After a successful publish, the workflow moves `snapshot/latest` to the published commit.
 
+The `snapshot/latest` marker is an annotated tag. Its tag message contains the published snapshot manifest, including
+the commit, snapshot repository URL, and the Gradle path plus Maven coordinates for each published component. The same
+manifest is written to the workflow step summary.
+
+To preview the manifest locally:
+
+```bash
+scripts/ci/write-snapshot-manifest.sh
+```
+
 The workflow performs these Gradle steps:
 
 ```bash

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -42,6 +42,9 @@ account password.
 The publish workflows pass these secrets to Gradle as environment-backed project properties through
 `ORG_GRADLE_PROJECT_*` environment variables.
 
+`SIGNING_IN_MEMORY_KEY_ID` must be set to the Gradle signing key ID, not the full key fingerprint. Use the short
+hexadecimal key ID, for example `00B5050F`. If you have the full fingerprint, use its last 8 hexadecimal characters.
+
 ## Release
 
 Releases start with a release preparation pull request.

--- a/scripts/ci/write-snapshot-manifest.sh
+++ b/scripts/ci/write-snapshot-manifest.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output="${1:-/dev/stdout}"
+repository_url="${SNAPSHOT_REPOSITORY_URL:-https://central.sonatype.com/repository/maven-snapshots/}"
+commit="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+
+{
+  echo "# Published snapshot"
+  echo
+  echo "- Commit: ${commit}"
+  echo "- Repository: ${repository_url}"
+  echo
+  echo "| Gradle path | Coordinates |"
+  echo "| --- | --- |"
+} > "${output}"
+
+while IFS= read -r build_file; do
+  project_dir="${build_file%/build.gradle.kts}"
+  project_path=":${project_dir//\//:}"
+  artifact_id="${project_dir##*/}"
+  parent_path="${project_dir%/*}"
+  group_id="net.thunderbird.${parent_path//\//.}"
+
+  version_dir="${project_dir}"
+  version_file=""
+  while [[ "${version_dir}" != "." && "${version_dir}" != "/" ]]; do
+    if [[ -f "${version_dir}/version.properties" ]]; then
+      version_file="${version_dir}/version.properties"
+      break
+    fi
+    version_dir="$(dirname "${version_dir}")"
+  done
+
+  if [[ -z "${version_file}" ]]; then
+    echo "No version.properties found for ${project_path}" >&2
+    exit 1
+  fi
+
+  # shellcheck disable=SC1090
+  source "${version_file}"
+  version="${MAJOR}.${MINOR}.${PATCH}-SNAPSHOT"
+
+  metadata_path="${group_id//.//}/${artifact_id}/${version}/maven-metadata.xml"
+  metadata_url="${repository_url%/}/${metadata_path}"
+  echo "| \`${project_path}\` | [\`${group_id}:${artifact_id}:${version}\`](${metadata_url}) |" >> "${output}"
+done < <(find components -name build.gradle.kts -print | sort)


### PR DESCRIPTION
To better document the released version this adds manifests for snapshots and releases to announce the published coordinates as part of the tag and GitHub release.
