### PR TITLE
chore(l10n): add Weblate base component configuration

### DIFF
--- a/config/weblate/README.md
+++ b/config/weblate/README.md
@@ -1,0 +1,15 @@
+# Weblate configuration
+
+This directory contains repository files used only to configure Weblate.
+
+The Compose resource at:
+
+```text
+composeResources/values/values.xml
+```
+
+provides a minimal base-language file for a Weblate base component. It exists to work around Weblate’s requirement for 
+a valid source file when creating a component whose configuration is reused by other components.
+
+The resource is not part of any application module and must not be included in a build. Its string is marked 
+with `translatable="false"` because it is only a configuration placeholder.

--- a/config/weblate/composeResources/values/strings.xml
+++ b/config/weblate/composeResources/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="weblate_base_component" translatable="false">Weblate base component</string>
+</resources>


### PR DESCRIPTION
Adds a minimal Compose resource under `config/weblate` to support creation of the Weblate base component. The placeholder is not part of any application module and is marked as non-translatable.